### PR TITLE
spidermanve .ini update

### DIFF
--- a/external/vpx-spidermanve/table.ini
+++ b/external/vpx-spidermanve/table.ini
@@ -1,11 +1,11 @@
 [TableOverride]
 ViewCabMode = 2
-ViewCabScaleX = 1.300211
-ViewCabScaleY = 1.020362
+ViewCabScaleX = 1.216065
+ViewCabScaleY = 1.014342
 ViewCabScaleZ = 0.996211
 ViewCabRotation = 180.000000
-ViewCabHOfs = 3.959099
-ViewCabVOfs = 0
+ViewCabHOfs = 0.753100
+ViewCabVOfs = 5.202395
 ViewCabWindowTop = 333.260742
 ViewCabWindowBot = 138.340256
 
@@ -18,9 +18,8 @@ ScreenInclination = 0.000000
 OverrideTableEmissionScale = 1
 DynamicDayNight = 0
 EmissionScale = 1.000000
-MaxTexDimension = 3072
-FXAA = 1
 ScreenPlayerX = -0.030400
+;AAfactor = 0.9
 
 [TableOption]
 Cabinet Mode = 1.000000

--- a/external/vpx-spidermanve/table.ini
+++ b/external/vpx-spidermanve/table.ini
@@ -19,7 +19,6 @@ OverrideTableEmissionScale = 1
 DynamicDayNight = 0
 EmissionScale = 1.000000
 ScreenPlayerX = -0.030400
-;AAfactor = 0.9
 
 [TableOption]
 Cabinet Mode = 1.000000


### PR DESCRIPTION
Removed MTD, FXAA.  Kept BBS. BBS 0.416666 was best adj to keep near 60 FPS during MB and other modes. Slight POV adjustment to give it a little more cab sidewall and nudge down.  Took restraint not to find another 3scr B2s with DMD container, and add some altcolor.  Will revisit our friendly neighborhood table in the future for more enhancements.  60 FPS upgrade is amazing enough, some may even say spectacular 🕸️

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
