### PR TITLE
spacejam update .ini and .yml FPS

### DIFF
--- a/external/vpx-spacejam/table.ini
+++ b/external/vpx-spacejam/table.ini
@@ -4,7 +4,6 @@ AlphaRampAccuracy = 4
 OverrideTableEmissionScale = 1
 DynamicDayNight = 0
 EmissionScale = 0.163975
-AAFactor = .95
 
 [TableOverride]
 ViewCabMode = 2

--- a/external/vpx-spacejam/table.yml
+++ b/external/vpx-spacejam/table.yml
@@ -2,7 +2,7 @@
 backglassVPSId: "Cu7Wm1bjxA"
 backglassChecksum: "9c87a44775307e9b4f0a29fea6bd0389"
 backglassNotes: "Download version 2.0"
-fps: 54
+fps: 60
 romVPSId: "dFDjrnqe"
 romChecksum: "7749a2f0739dd73bbe68350f28ef0941"
 tableVPSId: "nrzNYtRn"


### PR DESCRIPTION
Remove AAFactor 0.95 (in defaults) and increased FPS from 54 to 60 on .yml.  Still needs BBS 0.416666 to get near 60 FPS and play smooth.  There are very brief few second FPS drops in the 50's  in certain ramps seqeunces, not common.  But rest of game is at 60 with a strong 58+ MB.

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
