### PR TITLE
jplordoftherings .ini update

### DIFF
--- a/external/vpx-jplordoftherings/table.ini
+++ b/external/vpx-jplordoftherings/table.ini
@@ -6,11 +6,11 @@ PUPPlugin = 1
 [TableOverride]
 ViewCabMode = 2
 ViewCabScaleX = 1.225994
-ViewCabScaleY = 1.064896
+ViewCabScaleY = 1.034180
 ViewCabScaleZ = 1.000000
 ViewCabRotation = 180.000000
 ViewCabHOfs = 0.000000
-ViewCabVOfs = 0
+ViewCabVOfs = 0.000000
 ViewCabWindowTop = 370.541931
 ViewCabWindowBot = 97.853256
 ToneMapper = 0


### PR DESCRIPTION
 Minor POV change Y scale reduction.  Lights at top of back wall and cards at bottom were slightly cutoff. Table has MTD value double the default 4096 in current .ini.  Left it in and it does seem to crisp it up a tad. Looks/plays great with or without it.

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
